### PR TITLE
ROOM 4: graph neighbourhood added

### DIFF
--- a/snippets/graph_neighbourhood.py
+++ b/snippets/graph_neighbourhood.py
@@ -1,0 +1,68 @@
+""""""
+
+from itertools import starmap
+from operator import le, lt, and_
+from pathlib import Path
+from os import path
+from sys import argv, stdout
+from argparse import ArgumentParser
+
+from data import load_graph
+
+
+def neighbourhood(coord: tuple[int, int], borders) -> None:
+    n, s, w, e, nw, ne, sw, se = [
+        (-1, 0),
+        (1, 0),
+        (0, -1),
+        (0, 1),
+        (-1, -1),
+        (-1, 1),
+        (1, -1),
+        (1, 1),
+    ]
+    return filter(
+        lambda l: and_(*starmap(le, zip((0, 0), l)))
+        and and_(*starmap(lt, zip(l, borders))),
+        map(lambda n: tuple(map(sum, zip(coord, n))), (n, s, w, e, nw, ne, sw, se)),
+    )
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        description="Determine the list of arcs in the input Graph whose weight is greater or equal to their neighbour coordinates."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        required=True,
+        help="Path of the input file containing the list of coordinates to check",
+        dest="data_filepath",
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, dest="logfile_output_path", default=None
+    )
+
+    cli_args = parser.parse_args()
+    adj_matrix = load_graph(cli_args.data_filepath, sparse=False, fillna_with=0)
+    N = len(adj_matrix)
+
+    nn = list()
+    for u, _ in enumerate(adj_matrix):
+        for v, w in enumerate(adj_matrix[u]):
+            for (i, j) in neighbourhood((u, v), borders=(N, N)):
+                if w >= adj_matrix[i][j]:
+                    nn.append((u, v))
+    print(f"Found {len(nn)} edges in the input Graph satisfying the condition.")
+
+    if (
+        cli_args.logfile_output_path is not None
+        and cli_args.logfile_output_path.exists()
+    ):
+        logfile = open(cli_args.logfile_output_path, "w")
+    else:
+        logfile = stdout
+
+    for edge in nn:
+        print(f"{edge}", file=logfile)


### PR DESCRIPTION
This PR will add to the repo a Python module to determine the list of arcs in a graph whose weight is greater or equal to their corresponding neighbour coordinates.

The module includes a `neighbourhood` function that determines the neighbourhood of each node which is independent, and importable from other third-party code. 

The module _also_ contains a **main** section to run and test the program that is working with some input file representing the connections between nodes in a graph.

**Note**:
I'd like to receive comments and suggestions about the organisation of the code, and whether you think my code could be improved in *any* way. 
This is my **first** contribution to the project, and I am not very experienced in Python. 
I've read guidelines on how to contribute to the repo, but I'd love to receive any comments you might have. 